### PR TITLE
Fix "unable to fetch splatfest" error for US region

### DIFF
--- a/views/MainView.tsx
+++ b/views/MainView.tsx
@@ -206,12 +206,6 @@ const MainView = () => {
     t("lang")
   );
   const [region, setRegion, clearRegion, regionReady] = useStringMmkv(Key.Region, t("region"));
-  useEffect(() => {
-    // HACK: fix for legacy data, can be removed later.
-    if (region === "NA") {
-      setRegion("US");
-    }
-  }, []);
 
   const [icon, setIcon, clearIcon] = useStringMmkv(Key.Icon);
   const [level, setLevel, clearLevel] = useStringMmkv(Key.Level);
@@ -333,6 +327,11 @@ const MainView = () => {
             const newFilter = deepCopy(filter);
             newFilter.players = [];
             setFilter(newFilter);
+          }
+          // Fix for legacy data: "NA" was incorrectly used for the `the_americas_australia_new_zealand` region
+          // The `region` should match the key in the response of `splatoon3.ink/data/festivals.json`
+          if (region === "NA") {
+            setRegion("US");
           }
           const upgrade = await Database.open();
           if (upgrade) {

--- a/views/MainView.tsx
+++ b/views/MainView.tsx
@@ -206,6 +206,12 @@ const MainView = () => {
     t("lang")
   );
   const [region, setRegion, clearRegion, regionReady] = useStringMmkv(Key.Region, t("region"));
+  useEffect(() => {
+    // HACK: fix for legacy data, can be removed later.
+    if (region === "NA") {
+      setRegion("US");
+    }
+  }, []);
 
   const [icon, setIcon, clearIcon] = useStringMmkv(Key.Icon);
   const [level, setLevel, clearLevel] = useStringMmkv(Key.Level);

--- a/views/MainView.tsx
+++ b/views/MainView.tsx
@@ -153,7 +153,7 @@ enum TimeRange {
 
 enum Region {
   JP = "japan",
-  NA = "the_americas_australia_new_zealand",
+  US = "the_americas_australia_new_zealand",
   EU = "europe",
   AP = "hong_kong_south_korea",
 }
@@ -2218,7 +2218,7 @@ const MainView = () => {
                 title={t("change_splatfest_region", { region: t(Region[region]) })}
                 items={[
                   { key: "JP", value: t("japan") },
-                  { key: "NA", value: t("the_americas_australia_new_zealand") },
+                  { key: "US", value: t("the_americas_australia_new_zealand") },
                   { key: "EU", value: t("europe") },
                   { key: "AP", value: t("hong_kong_south_korea") },
                 ]}


### PR DESCRIPTION
Reproduce: Switch Splatfest Region to NA and refresh

-----


https://splatoon3.ink/data/festivals.json

The `the_americas_australia_new_zealand` region code is actually `US` in `splatoon3.ink`'s API. I remember it was working months ago. So they might changed the key at some point.

This PR fixed it by renaming `NA` to `US`. 
It also corrects value in the user's database, so we can completely remove the temporary fix in the future.

If `splatoon3.ink` changes the key back to `NA` in the future, we might want to keep using `NA` and add a function like `getSplatoon3InkRegion(region)` to handle converting NA to US.