### PR TITLE
Fix incorrect weapon names (image ids) in filter view

### DIFF
--- a/utils/database.ts
+++ b/utils/database.ts
@@ -550,7 +550,7 @@ export const add = async (
     }
     for (const w of weapon.split(",")) {
       if (w) {
-        filterOptions.weapons.add(w);
+        filterOptions.weapons.add(weaponList.images[w] ?? w);
       }
     }
   }


### PR DESCRIPTION

It happens when there is a new weapon in the refreshed histories (can be resolved by restart the app).

Reproduce:

1. Export a long history
2. Clear the database
3. Restart the app
4. Refresh
5. Import the package with a long history (just to make sure some new weapons are added)

<img width="440" alt="image" src="https://github.com/user-attachments/assets/86fbb9fa-8496-454f-8bff-2c90f27a72a3">